### PR TITLE
Changing the comparison operator from == to !== to resolve issues with jshint runners complaining

### DIFF
--- a/js/jquery-eu-cookie-law-popup.js
+++ b/js/jquery-eu-cookie-law-popup.js
@@ -172,7 +172,7 @@ $.fn.euCookieLawPopup = (function() {
 		var cookies = document.cookie.split(";");
 		for (var i = 0; i < cookies.length; i++) {
 			var c = cookies[i].trim();
-			if (c.indexOf(_self.vars.COOKIE_NAME) == 0) {
+			if (c.indexOf(_self.vars.COOKIE_NAME) !== -1) {
 				userAcceptedCookies = c.substring(_self.vars.COOKIE_NAME.length + 1, c.length);
 			}
 		}


### PR DESCRIPTION
Minor change to the comparison operator causing one of our Grunt task runners (jshint) to throw an error.

BEFORE:

```
$ grunt js --force
Running "jshint:all" (jshint) task

   web/assets/src/js/jquery-eu-cookie-law-popup.js
    175 |            if (c.indexOf(_self.vars.COOKIE_NAME) == 0) {
                                                           ^ Use '===' to compare with '0'.

>> 1 error in 34 files
Warning: Task "jshint:all" failed. Used --force, continuing.

Running "uglify:build" (uglify) task
>> 1 file created.

Done, but with warnings.
```

AFTER:

```
$ grunt js
Running "jshint:all" (jshint) task
>> 34 files lint free.

Running "uglify:build" (uglify) task
>> 1 file created.

Done, without errors.
```