### PR TITLE
Fixing setUserAcceptsCookies() issue for button eupopup-closebutton

### DIFF
--- a/js/jquery-eu-cookie-law-popup.js
+++ b/js/jquery-eu-cookie-law-popup.js
@@ -229,7 +229,7 @@ $.fn.euCookieLawPopup = (function() {
 				return false;
 			});
 			$('.eupopup-closebutton').click(function() {
-				setUserAcceptsCookies(true);
+				setUserAcceptsCookies(false);
 				hideContainer();
 				return false;
 			});


### PR DESCRIPTION
it supposed that when the user clicks the close button to pass a false parameter to the setUserAcceptsCookies() function but that wasn't the case and the EU_COOKIE_LAW_CONSENT cookie was always set to true.